### PR TITLE
Add note about empty paragraphs to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ $PANDOC_TEMPLATES_HOME/bin/md2long.sh --output $HOME/somecoolstory.docx --overwr
 
 For Windows (using PowerShell 5.0 or greater): **under revision**
 
+### Paragraph Breaks
+
+Use an empty paragraph to create a space between two scenes. An empty paragraph can be created by escaping a space character:
+
+```
+
+\ 
+
+```
+
 ## Credits
 
 * [Pandoc](https://pandoc.org): Document Conversion Utility


### PR DESCRIPTION
It took me a few minutes to work out how to leave an empty paragraph between two scenes, so I thought it might be useful to add a note regarding this to the readme.

I'm unsure if this is the best method, and not certain if the wording is very clear.

Might it be better to have an example .md file included in the repo that demonstrates both this and the frontmatter?

Edit: This is all wonderfully documented in shunn/short/guidelines.md, closing