### PR TITLE
Add a word joiner before em dashes

### DIFF
--- a/filters/nonbreakemdash.lua
+++ b/filters/nonbreakemdash.lua
@@ -1,0 +1,15 @@
+-- Add a unicode "word joiner" (code point 2060) at the beginning of em dashes
+--
+-- Without this, lines in the docx can break just before an em dash, leaving
+-- the em dash at the beginning of the next line.  The word joiner disallows
+-- breaking the line between the preceding word and the em dash.
+
+function Str(elem)
+   -- Note that all instance of "—" below are an em dash, *not* a hyphen.  Be
+   -- careful when editing.
+   if string.find(elem.text, "—") then
+	  return pandoc.Str(string.gsub(elem.text, "—", "\u{2060}—"))
+   else
+	  return elem
+   end
+end

--- a/shunn/long/shunnlong.lua
+++ b/shunn/long/shunnlong.lua
@@ -3,6 +3,7 @@ require "filters.wordcount"
 require "filters.meta"
 require "filters.docx.horizontalrule"
 require "filters.docx.processheader"
+require "filters.nonbreakemdash"
 
 vars = {}
 

--- a/shunn/short/shunnshort.lua
+++ b/shunn/short/shunnshort.lua
@@ -3,6 +3,7 @@ require "filters.wordcount"
 require "filters.meta"
 require "filters.docx.horizontalrule"
 require "filters.docx.processheader"
+require "filters.nonbreakemdash"
 
 vars = {}
 


### PR DESCRIPTION
This change addresses #18, adding a pandoc filter to both the long and short output formats that adds a
"word joiner" (unicode code point 2060) before em dashes.

Without the word joiner, output lines in the docx can break between a preceding
word and an em dash, leading to output like this, with the awkward leading em dash:

```
...he looked through the door
--the old, wooden door--and saw...
```

With the word joiner, the lines are forced to break like this:

```
...he looked through the door--
the old, wooden door--and saw...
```

or like this:

```
...he looked through the
door--the old, wooden door--and saw...
```