### PR TITLE
Add a 'verbose' flag.

### DIFF
--- a/bin/md2long.sh
+++ b/bin/md2long.sh
@@ -14,6 +14,7 @@ LUA_PATH="$FILTERS_PATH/?.lua;;"
 PANDOC_TEMPLATES="$(dirname "$SCRIPT_PATH")"
 SHUNN_LONG_STORY_DIR="$PANDOC_TEMPLATES/shunn/long"
 FROM_FORMAT='markdown'
+VERBOSE='0'
 
 # https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash/
 FILES=()
@@ -34,6 +35,8 @@ md2long.sh --output DOCX [--overwrite] [--modern] FILES
     Use Shunn modern manuscript format (otherwise use Shunn classic)
   -f                    --from=FORMAT
     Input document format, passed to pandoc. Defaults to 'markdown'.
+  -v                    --verbose
+    Print progress messages.
   FILES
     One (1) or more Markdown file(s) to be converted to DOCX.
     Passed straight to pandoc as-is.
@@ -59,12 +62,22 @@ md2long.sh --output DOCX [--overwrite] [--modern] FILES
     shift # past argument
     shift # past value
     ;;
+    -v|--verbose)
+    VERBOSE="1"
+    shift
+    ;;
     *)    # files to process
     FILES+=("$1")
     shift # past argument
     ;;
   esac
 done
+
+function echo_if_verbose() {
+    if [[ "$VERBOSE" == '1' ]]; then
+        echo "${@}"
+    fi
+}
 
 if [[ -z "$OUTFILE" ]]; then
   echo "No --output argument given."
@@ -92,29 +105,30 @@ else
 fi
 
 # Create a temporary data directory
-echo "Creating temporary directory."
+echo_if_verbose "Creating temporary directory."
 export PANDOC_DATA_DIR
 PANDOC_DATA_DIR="$(mktemp -d)"
-echo "Directory created: $PANDOC_DATA_DIR"
+echo_if_verbose "Directory created: $PANDOC_DATA_DIR"
 
 # Prep the template and reference directories
-echo "Extracting $SHUNN_LONG_STORY_DIR/$TEMPLATE to temporary directory."
+echo_if_verbose "Extracting $SHUNN_LONG_STORY_DIR/$TEMPLATE to temporary directory."
 unzip -ao "$SHUNN_LONG_STORY_DIR/$TEMPLATE" -d "$PANDOC_DATA_DIR/template" > /dev/null
 unzip -ao "$SHUNN_LONG_STORY_DIR/$TEMPLATE" -d "$PANDOC_DATA_DIR/reference" > /dev/null
-echo "Files extracted."
+echo_if_verbose "Files extracted."
 
 # Run pandoc
-echo "Running Pandoc."
+echo_if_verbose "Running Pandoc."
 pandoc \
   "--from=$FROM_FORMAT" \
   --to=docx \
+  "--metadata=shunn_verbose:$VERBOSE" \
   --lua-filter="$SHUNN_LONG_STORY_DIR/shunnlong.lua" \
   --data-dir="$PANDOC_DATA_DIR" \
   --output="$OUTFILE" \
   "${FILES[@]:0}"
-echo "Pandoc completed successfully."
+echo_if_verbose "Pandoc completed successfully."
 
 # Clean up the temporary directory
-echo "Removing $PANDOC_DATA_DIR"
+echo_if_verbose "Removing $PANDOC_DATA_DIR"
 rm -rf "$PANDOC_DATA_DIR"
-echo "Done."
+echo_if_verbose "Done."

--- a/shunn/long/shunnlong.lua
+++ b/shunn/long/shunnlong.lua
@@ -6,9 +6,13 @@ require "filters.docx.processheader"
 
 vars = {}
 
-function Pandoc(doc, meta)
+function Pandoc(doc)
   local ossep = package.config:sub(1,1)
   local pandoc_data_dir = os.getenv('PANDOC_DATA_DIR')
+  local verbose = false
+  if doc.meta['shunn_verbose'] == '1' then
+    verbose = true
+  end
 
   pandoc.walk_block(pandoc.Div(doc.blocks), wordcount)
 
@@ -24,19 +28,25 @@ function Pandoc(doc, meta)
   -- https://stackoverflow.com/questions/295052/how-can-i-determine-the-os-of-the-system-from-within-a-lua-script
   if ossep == '/' then
     -- *nix (MacOS, Linux) should have zip available
-    print("Zipping reference.docx using UNIX zip.")
+    if verbose then
+      print("Zipping reference.docx using UNIX zip.")
+    end
     os.execute ("cd "
       .. pandoc_data_dir
       .. "/reference && zip -r ../reference.docx * > /dev/null")
   elseif ossep == '\\' then
     -- Windows should have powershell
-    print("Zipping reference.zip using PowerShell.")
+    if verbose then
+      print("Zipping reference.zip using PowerShell.")
+    end
     os.execute("powershell Compress-Archive -Path "
       .. pandoc_data_dir
       .. "\\reference\\* "
       .. pandoc_data_dir
       .. "\\reference.zip")
-    print("Renaming reference.zip to reference.docx.")
+    if verbose then
+      print("Renaming reference.zip to reference.docx.")
+    end
     os.execute("powershell Rename-Item -Path "
       .. pandoc_data_dir
       .. "\\reference.zip -NewName "

--- a/shunn/short/shunnshort.lua
+++ b/shunn/short/shunnshort.lua
@@ -6,9 +6,13 @@ require "filters.docx.processheader"
 
 vars = {}
 
-function Pandoc(doc, meta)
+function Pandoc(doc)
   local pandoc_data_dir = os.getenv('PANDOC_DATA_DIR')
   local ossep = package.config:sub(1,1)
+  local verbose = false
+  if doc.meta['shunn_verbose'] == '1' then
+    verbose = true
+  end
 
   pandoc.walk_block(pandoc.Div(doc.blocks), wordcount)
 
@@ -23,19 +27,25 @@ function Pandoc(doc, meta)
   -- https://stackoverflow.com/questions/295052/how-can-i-determine-the-os-of-the-system-from-within-a-lua-script
   if ossep == '/' then
     -- *nix (MacOS, Linux) should have zip available
-    print("Zipping reference.docx using UNIX zip.")
+    if verbose then
+      print("Zipping reference.docx using UNIX zip.")
+    end
     os.execute ("cd "
       .. pandoc_data_dir
       .. "/reference && zip -r ../reference.docx * > /dev/null")
   elseif ossep == '\\' then
     -- Windows should have powershell
-    print("Zipping reference.zip using PowerShell.")
+    if verbose then
+      print("Zipping reference.zip using PowerShell.")
+    end
     os.execute("powershell Compress-Archive -Path "
       .. pandoc_data_dir
       .. "\\reference\\* "
       .. pandoc_data_dir
       .. "\\reference.zip")
-    print("Renaming reference.zip to reference.docx.")
+    if verbose then
+      print("Renaming reference.zip to reference.docx.")
+    end
     os.execute("powershell Rename-Item -Path "
       .. pandoc_data_dir
       .. "\\reference.zip -NewName "

--- a/test/run.sh
+++ b/test/run.sh
@@ -13,7 +13,7 @@ line='----------------------------------------'
 printf $fH '================== Bash Tests =================='
 
 printf $fS '1. [Short] Single input' $line
-$BIN/md2short.sh --overwrite $THIS_DIR/short/guidelines.md --output $RESULTS/short.docx
+$BIN/md2short.sh --verbose --overwrite $THIS_DIR/short/guidelines.md --output $RESULTS/short.docx
 
 printf $fS '2. [Short] Other input format' $line
 $BIN/md2short.sh --overwrite --from json $THIS_DIR/short/guidelines.json --output $RESULTS/short-json.docx
@@ -22,7 +22,7 @@ printf $fS '3. [Short] Modern style' $line
 $BIN/md2short.sh -x --modern $THIS_DIR/short/line-break.md -o $RESULTS/short-modern.docx
 
 printf $fS '4. [Long] Wildcard inputs' $line
-$BIN/md2long.sh -x $THIS_DIR/long/*.md $THIS_DIR/short/*.md -o $RESULTS/long.docx
+$BIN/md2long.sh -v -x $THIS_DIR/long/*.md $THIS_DIR/short/*.md -o $RESULTS/long.docx
 
 printf $fS '5. [Long] Other input format' $line
 $BIN/md2long.sh -x --from json $THIS_DIR/long/*.json $THIS_DIR/short/*.json -o $RESULTS/long-json.docx


### PR DESCRIPTION
Add a 'verbose' flag.

Now, by default, the scripts don't print anything unless they need user input or something goes wrong.

Fixes https://github.com/prosegrinder/pandoc-templates/issues/20